### PR TITLE
use file suffix

### DIFF
--- a/autoload/sass-colors.rb
+++ b/autoload/sass-colors.rb
@@ -278,11 +278,11 @@ HEX_VALS = CLUT_HASH.keys
 
 
 prefix_regex = /\/(?:stylesheets|sass|scss)\//
-# suffix_regex = /\.(?:scss|sass|less)/
+suffix_regex = /\.(?:scss|sass|less)/
 
 current_file = ARGV[0]
-#$suffix = current_file[suffix_regex]
-$suffix = ".*"
+$suffix = current_file[suffix_regex]
+# $suffix = ".*"
 current_dir = ARGV[0].sub(/\/[^\/]+$/,'')
 style_root_key = current_file[prefix_regex]
 if style_root_key


### PR DESCRIPTION
this fixes issues when encountering a file of the wrong suffix type

In the future we may want to do this via regex somehow, but Dir.glob doesn't accept regex